### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1,5 +1,8 @@
 name: PR check
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/allen0099/utaipei-course-web/security/code-scanning/4](https://github.com/allen0099/utaipei-course-web/security/code-scanning/4)

Add an explicit `permissions` block to the workflow so the `GITHUB_TOKEN` is least-privileged.  
Best fix here: define permissions at the workflow root (applies to all jobs unless overridden), with:

- `contents: read`

This preserves current functionality (checkout/build only) while eliminating implicit permission inheritance.

Edit file: `.github/workflows/pr-check.yml`  
Change region: after `name:` and before `on:` (top-level keys).  
No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
